### PR TITLE
Fix when deactivating already disposed controller

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -617,7 +617,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
   @override
   void deactivate() {
     super.deactivate();
-    widget.controller.removeListener(_listener);
+    widget.controller?.removeListener(_listener);
   }
 
   @override


### PR DESCRIPTION
Often, when player is disposed on low-end devices, this deactivate is called which causes UI exception.